### PR TITLE
Stop automatically converting long tracking numbers to float, which c…

### DIFF
--- a/Ui/Component/Listing/Column/TrackAndTrace.php
+++ b/Ui/Component/Listing/Column/TrackAndTrace.php
@@ -97,7 +97,8 @@ class TrackAndTrace extends Column
         }
 
         $trackData    = $order->getData('track_number') ?? '';
-        $trackNumbers = json_decode($trackData, true) ?? $trackData;
+        // add JSON_BIGINT_AS_STRING as flag, so that big numbers don't get converted to floats, which both breaks the explode function and misrepresent the number completely with its scientific notation
+        $trackNumbers = json_decode($trackData, true, 512, JSON_BIGINT_AS_STRING) ?? $trackData;
 
         // older shipments are stored with '<br>' as separator between trackNumbers
         if (! is_array($trackNumbers)) {


### PR DESCRIPTION
…an break the order grid in the backoffice.

Seen on a Magento shop of one of our clients, the backoffice order grid crashed with:
```
explode(): Argument #2 ($string) must be of type string, float given
Exception in vendor/myparcelbe/magento/Ui/Component/Listing/Column/TrackAndTrace.php:104
```

In this particular case, there were some order tracking numbers from bpost that are very long.
Example: `323211623959980123456789`
When calling `json_decode` on this string, it will get converted to a `float` automatically, which breaks the `explode` function as that one expects a variable with type `string`.
A naive approach to fixing this, would be to cast this value to a string before passing it to the `explode` function, but that's not a good way to fix this, as the float would then be represented as a string in scientific notation: `3.2321162395998E+23` which is really not okay.
So the best way to fix this in my research is to pass the flag `JSON_BIGINT_AS_STRING` to `json_decode` to prevent this function from converting this big numbers to a float in the first place.


Maybe this fix will need to be ported to https://github.com/myparcelnl/magento as well, but I'll leave that up to you guys to figure out.